### PR TITLE
remove next_session_id, make ID 0-based

### DIFF
--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -186,7 +186,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 fn spawn_session(
     sessions: &mut JoinSet<SessionReport>,
-    session_id: usize,
+    previous_session_id: usize,
     model: Arc<Model<'static>>,
     license: String,
     config: ProcessorConfig,
@@ -195,7 +195,7 @@ fn spawn_session(
     stop: Arc<AtomicBool>,
 ) {
     sessions.spawn(run_session(
-        session_id,
+        previous_session_id + 1,
         model,
         license,
         config,

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -61,11 +61,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut sessions = JoinSet::new();
     let mut reports = Vec::new();
     let mut spawned_sessions = 0usize;
-    let mut next_session_id = 1usize;
 
     spawn_session(
         &mut sessions,
-        next_session_id,
+        spawned_sessions,
         Arc::clone(&model),
         license.clone(),
         config.clone(),
@@ -85,10 +84,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let first_failed_report = loop {
         tokio::select! {
             _ = spawn_ticks.tick() => {
-                next_session_id += 1;
                 spawn_session(
                     &mut sessions,
-                    next_session_id,
+                    spawned_sessions,
                     Arc::clone(&model),
                     license.clone(),
                     config.clone(),


### PR DESCRIPTION
It looks like the session ID isn't used anyway, but maybe that's useful for debugging?