### PR TITLE
Use --all-targets for Clippy

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      - run: RUSTFLAGS="-D warnings" cargo clippy --all-features
+      - run: RUSTFLAGS="-D warnings" cargo clippy --all-features --all-targets
 
   doc:
     name: Documentation

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -98,7 +98,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                 print!("*");
                 if active_threads.is_multiple_of(50) {
-                    print!("\n");
+                    println!();
                 }
 
                 std::io::stdout().flush().unwrap();
@@ -194,6 +194,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn spawn_session(
     session_id: usize,
     model: Arc<Model<'static>>,

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -818,10 +818,9 @@ mod tests {
                 .and_then(|n| n.to_str())
                 .map(|name| name.contains("rook_s_48khz") && name.ends_with(".aicmodel"))
                 .unwrap_or(false)
+                && path.is_file()
             {
-                if path.is_file() {
-                    return Some(path);
-                }
+                return Some(path);
             }
         }
         None
@@ -841,13 +840,9 @@ mod tests {
             return Ok(existing);
         }
 
-        #[cfg(feature = "download-model")]
-        {
-            return Model::download("rook-s-48khz", target_dir);
-        }
-
-        #[cfg(not(feature = "download-model"))]
-        {
+        if cfg!(feature = "download-model") {
+            Model::download("rook-s-48khz", target_dir)
+        } else {
             panic!(
                 "Model `rook-s-48khz` not found in {} and `download-model` feature is disabled",
                 target_dir.display()


### PR DESCRIPTION
I noticed that Clippy was complaining in my editor but it didn't in CI. Adding `--all-targets` gives the same warnings as in my editor.