### PR TITLE
Add async processor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.91.0
-      - name: Build and Run Example
+      - name: Build and Run Examples
         run: |
           cargo run --example basic_usage --all-features
           cargo run --package build-time-download --features download-lib
+          cargo run --example parallel_async --all-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ## New Features
 
-- Added `ProcessorAsync`, an async wrapper around `Processor` that offloads processing to a background thread pool, gated behind the new `async-processor` feature. The implementation is runtime-agnostic and works on any executor (tokio, smol, async-std, ...).
+- Added `ProcessorAsync`, an async wrapper around `Processor` that offloads processing to a background thread pool, gated behind the new `async` feature. The implementation is runtime-agnostic and works on any executor (tokio, smol, async-std, ...).
 
   ```toml
   [dependencies]
-  aic-sdk = { version = "0.18", features = ["async-processor"] }
+  aic-sdk = { version = "0.18", features = ["async"] }
   ```
 
   ```rust,no_run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 0.18.0 - 2026-05-19
+
+## New Features
+
+- Added `ProcessorAsync`, an async wrapper around `Processor` that offloads processing to a background thread pool, gated behind the new `async-processor` feature. The implementation is runtime-agnostic and works on any executor (tokio, smol, async-std, ...).
+
+  ```toml
+  [dependencies]
+  aic-sdk = { version = "0.18", features = ["async-processor"] }
+  ```
+
+  ```rust,no_run
+  use aic_sdk::{Model, ProcessorAsync, ProcessorConfig};
+
+  #[tokio::main]
+  async fn main() -> Result<(), aic_sdk::AicError> {
+      let model = Model::from_file("/path/to/model.aicmodel")?;
+      let config = ProcessorConfig::optimal(&model).with_num_channels(2);
+      let processor = ProcessorAsync::with_config(&model, "license", &config).await?;
+
+      let audio = vec![0.0f32; config.num_channels as usize * config.num_frames];
+      let audio = processor.process_interleaved(audio).await?;
+      Ok(())
+  }
+  ```
+
 ## 0.17.1 - 2026-05-06
 
 ## Improvements
@@ -81,7 +107,6 @@
 
 - Fixed an issue allowing users to change processor parameters with certain models
 
-
 ## 0.13.0 - 2026-01-14
 
 This release integrates ai-coustics C library version 0.13.0, which comes with a number of new features and several breaking changes.
@@ -93,6 +118,7 @@ Most notably, the C library no longer includes any models, which significantly r
 **Model naming changes**: Quail-STT models are now called "Quail" - These models are optimized for human-to-machine enhancement (e.g., Speech-to-Text (STT) applications). Quail models are now called "Sparrow" - These models are optimized for human-to-human enhancement (e.g., voice calls, conferencing). This naming change clarifies the distinction between STT-focused models and human-to-human communication model
 
 **Major architectural change**: The API has been restructured to separate model data from processing instances. What was previously called `Model` (which handled both model data and processing) has been split into:
+
 - `Model`: Now represents only the ML model data loaded from files or memory
 - `Processor`: New type that performs the actual audio processing using a model
 - Multiple processors can share the same model, allowing efficient resource usage across streams
@@ -111,15 +137,15 @@ Most notably, the C library no longer includes any models, which significantly r
 - Added `ProcessorConfig::optimal()` helper that returns a configuration pre-filled with the model's optimal sample rate and frame count.
 - Added builder methods `ProcessorConfig::with_num_channels()` and `ProcessorConfig::with_allow_variable_frames()`.
 - Model query methods are now on `Model`:
-    - `Model::optimal_sample_rate()` - gets optimal sample rate for a model
-    - `Model::optimal_num_frames()` - gets optimal frame count for a model at given sample rate
+  - `Model::optimal_sample_rate()` - gets optimal sample rate for a model
+  - `Model::optimal_num_frames()` - gets optimal frame count for a model at given sample rate
 - Added new error variants for model loading:
-    - `AicError::ModelInvalid`
-    - `AicError::ModelVersionUnsupported`
-    - `AicError::ModelFilePathInvalid`
-    - `AicError::FileSystemError`
-    - `AicError::ModelDataUnaligned`
-    - `AicError::ModelDownload`
+  - `AicError::ModelInvalid`
+  - `AicError::ModelVersionUnsupported`
+  - `AicError::ModelFilePathInvalid`
+  - `AicError::FileSystemError`
+  - `AicError::ModelDataUnaligned`
+  - `AicError::ModelDownload`
 
 ### Breaking changes
 
@@ -128,14 +154,14 @@ Most notably, the C library no longer includes any models, which significantly r
 - Removed `Model::new()`, `Model::initialize()`, and `Model::process_*()` methods.
 - `Processor::initialize()` now takes a `ProcessorConfig` struct instead of discrete arguments.
 - `EnhancementParameter` was renamed to `ProcessorParameter`:
-    - `EnhancementParameter::Bypass` → `ProcessorParameter::Bypass`
-    - `EnhancementParameter::EnhancementLevel` → `ProcessorParameter::EnhancementLevel`
-    - `EnhancementParameter::VoiceGain` → `ProcessorParameter::VoiceGain`
+  - `EnhancementParameter::Bypass` → `ProcessorParameter::Bypass`
+  - `EnhancementParameter::EnhancementLevel` → `ProcessorParameter::EnhancementLevel`
+  - `EnhancementParameter::VoiceGain` → `ProcessorParameter::VoiceGain`
 - Parameter and control methods moved to `ProcessorContext` (obtained via `Processor::processor_context()`):
-    - `Model::reset()` → `ProcessorContext::reset()`
-    - `Model::parameter()` → `ProcessorContext::parameter()`
-    - `Model::set_parameter()` → `ProcessorContext::set_parameter()`
-    - `Model::output_delay()` → `ProcessorContext::output_delay()`
+  - `Model::reset()` → `ProcessorContext::reset()`
+  - `Model::parameter()` → `ProcessorContext::parameter()`
+  - `Model::set_parameter()` → `ProcessorContext::set_parameter()`
+  - `Model::output_delay()` → `ProcessorContext::output_delay()`
 - `set_parameter()` and `reset()` now take `&self` instead of `&mut self` (thread-safe).
 - `output_delay()` now returns `usize` directly instead of `Result`.
 - VAD construction moved from `Model::create_vad()` to `Processor::vad_context()` and now only needs `&self`.
@@ -153,12 +179,12 @@ Most notably, the C library no longer includes any models, which significantly r
 ### New features
 
 - Added new VAD parameter `VadParameter::MinimumSpeechDuration` used to control for how long speech needs to be present
-in the audio signal before the VAD considers it speech.
+  in the audio signal before the VAD considers it speech.
 
 ### Breaking changes
 
 - Replaced VAD parameter `VadParameter::LookbackBufferSize` with `VadParameter::SpeechHoldDuration`, used to control
-for how long the VAD continues to detect speech after the audio signal no longer contains speech.
+  for how long the VAD continues to detect speech after the audio signal no longer contains speech.
 
 ## 0.11.0 - 2025-12-11
 
@@ -219,40 +245,46 @@ for how long the VAD continues to detect speech after the audio signal no longer
 ## 0.9.0 - 2025-11-06
 
 ### Features
+
 - **Voice Activity Detection**: This release adds a new Quail-based VAD. The VAD automatically uses the output of a Quail model to calculate a voice activity prediction.
 
 ### Breaking Changes
+
 - `handle_error()`'s visibility is now `pub(crate)`.
 
 ## 0.8.2 - 2025-11-06
 
 ### Fixes
+
 - Fixed build error on macOS
 
 ## 0.8.1 - 2025-10-29
 
 ### Fixes
+
 - Fixed documentation build on docs.rs
 
 ## 0.8.0 - 2025-10-28
 
 ### New features
+
 - **Self-Service Licenses**: Starting with this release, you can use self-service licenses directly from our development portal.
 - **Usage-Based Telemetry**: This release introduces a new telemetry feature that collects usage data, paving the way for future usage-based pricing models such as pay-per-minute billing.
-    - **What we collect**: We collect only the processing time used and some diagnostic data
-    - **Privacy**: We do not collect any information about your audio content. Your audio never leaves your device during our processing.
-    - **Requirements**: Requires a constant internet connection. If the SDK cannot be activated online, enhancement will stop after 10 seconds. If telemetry data cannot be sent, enhancement will stop after 5 minutes. When enhancement is stopped an error will be returned, the audio will be bypassed and the processing delay will be still applied to ensure an uninterrupted audio stream without discontinuities.
-    - **Error Handling**: When processing is bypassed because our backend cannot be reached or does not allow you to process, the process functions will return `AicError::EnhancementNotAllowed`. Make sure to handle this error in your implementation.
-    - **Offline Licenses**: If you cannot provide a constant internet connection, please contact us to obtain a special offline license that does not require telemetry.
-
+  - **What we collect**: We collect only the processing time used and some diagnostic data
+  - **Privacy**: We do not collect any information about your audio content. Your audio never leaves your device during our processing.
+  - **Requirements**: Requires a constant internet connection. If the SDK cannot be activated online, enhancement will stop after 10 seconds. If telemetry data cannot be sent, enhancement will stop after 5 minutes. When enhancement is stopped an error will be returned, the audio will be bypassed and the processing delay will be still applied to ensure an uninterrupted audio stream without discontinuities.
+  - **Error Handling**: When processing is bypassed because our backend cannot be reached or does not allow you to process, the process functions will return `AicError::EnhancementNotAllowed`. Make sure to handle this error in your implementation.
+  - **Offline Licenses**: If you cannot provide a constant internet connection, please contact us to obtain a special offline license that does not require telemetry.
 
 ### Breaking changes
+
 - **Variable number of frames supported**: `Model::initialize` now supports a variable number of frames per call. To enable this feature, use the new `allow_variable_frames` parameter in the initialize function. Set allow_variable_frames to true to enable variable frame processing, or false to maintain the previous fixed frame behavior. Note that enabling variable frames results in higher processing delay.
 - **New bypass parameter**: A new parameter `Parameter::Bypass` has been added to control audio processing bypass while preserving algorithmic delay. When enabled, the input audio passes through unmodified, but the output is still delayed by the same amount as during normal processing. This ensures seamless transitions when toggling enhancement on/off without audible clicks or timing shifts.
 - **Updated Error Codes**: Expanded and renamed error variants, with additional license-related errors.
 - **Version API improved**: `aic_sdk_version()` was renamed to `aic_sdk::get_version()` and it now returns a `&'static str`.
 
 ### Fixes
+
 - The internal model state is now automatically reset when processing is paused (e.g., when bypass is enabled or enhancement level is set to 0). This ensures a clean state when processing resumes.
 - The reset operation now ensures that all internal DSP components are properly reset, providing a more thorough clean state.
 - Fixed an issue where, after a successful initialization, a subsequent initialization error would not properly block processing, potentially allowing operations on a partially initialized model.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,8 @@ dependencies = [
  "aic-sdk-sys",
  "approx",
  "audio-file",
+ "futures",
+ "rayon",
  "serde",
  "serde_json",
  "sha2",
@@ -298,6 +300,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -396,6 +423,94 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
  "zlib-rs",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
 ]
 
 [[package]]
@@ -805,6 +920,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "realfft"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1031,6 +1166,12 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "strength_reduce"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,8 +34,10 @@ version = "0.17.1"
 dependencies = [
  "aic-sdk-sys",
  "approx",
+ "async-lock",
  "audio-file",
  "futures",
+ "futures-channel",
  "rayon",
  "serde",
  "serde_json",
@@ -71,6 +73,17 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "audio-core"
@@ -261,6 +274,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,6 +411,27 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -829,6 +872,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "pbkdf2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,12 @@ version = "0.17.0"
 
 [workspace.dependencies]
 aic-sdk-sys = { version = "0.17.0", path = "aic-sdk-sys" }
+rayon = "1"
 serde = { version = "1.0" }
 serde_json = { version = "1.0" }
 sha2 = { version = "0.10" }
 thiserror = "2.0"
+tokio = { version = "1" }
 ureq = { version = "3.1", default-features = false }
 
 [package]
@@ -32,17 +34,20 @@ version.workspace = true
 
 [dependencies]
 aic-sdk-sys = { workspace = true }
+rayon = { workspace = true }
 serde = { workspace = true, optional = true, features = ["derive"] }
 serde_json = { workspace = true, optional = true }
 sha2 = { workspace = true, optional = true }
 thiserror = { workspace = true }
+tokio = { workspace = true, features = ["sync", "rt"] }
 ureq = { workspace = true, optional = true, features = ["rustls"] }
 
 [dev-dependencies]
 approx = "0.5"
 audio-file = "0.4.1"
+futures = "0.3"
 serde_json = { workspace = true }
-tokio = { version = "1.49", features = ["macros", "rt-multi-thread", "sync", "time"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
 
 [features]
 download-lib = ["aic-sdk-sys/download-lib"]
@@ -55,3 +60,7 @@ path = "examples/basic_usage.rs"
 [[example]]
 name = "benchmark"
 path = "examples/benchmark.rs"
+
+[[example]]
+name = "parallel_async"
+path = "examples/parallel_async.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ serde = { workspace = true, optional = true, features = ["derive"] }
 serde_json = { workspace = true, optional = true }
 sha2 = { workspace = true, optional = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["sync", "rt"] }
+tokio = { workspace = true, features = ["rt", "sync"] }
 ureq = { workspace = true, optional = true, features = ["rustls"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,12 +64,14 @@ rustdoc-args = ["--cfg", "docsrs"]
 [[example]]
 name = "basic_usage"
 path = "examples/basic_usage.rs"
+required-features = ["download-model"]
 
 [[example]]
 name = "benchmark"
 path = "examples/benchmark.rs"
+required-features = ["download-model"]
 
 [[example]]
 name = "parallel_async"
 path = "examples/parallel_async.rs"
-required-features = ["async"]
+required-features = ["async", "download-model"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ version = "0.17.1"
 
 [workspace.dependencies]
 aic-sdk-sys = { version = "0.17.1", path = "aic-sdk-sys" }
+async-lock = "3"
+futures-channel = { version = "0.3", default-features = false, features = ["std"] }
 rayon = "1"
 serde = { version = "1.0" }
 serde_json = { version = "1.0" }
@@ -34,12 +36,13 @@ version.workspace = true
 
 [dependencies]
 aic-sdk-sys = { workspace = true }
+async-lock = { workspace = true, optional = true }
+futures-channel = { workspace = true, optional = true }
 rayon = { workspace = true, optional = true }
 serde = { workspace = true, optional = true, features = ["derive"] }
 serde_json = { workspace = true, optional = true }
 sha2 = { workspace = true, optional = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["rt", "sync"], optional = true }
 ureq = { workspace = true, optional = true, features = ["rustls"] }
 
 [dev-dependencies]
@@ -50,7 +53,7 @@ serde_json = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
 
 [features]
-async-processor = ["dep:tokio", "dep:rayon"]
+async-processor = ["dep:async-lock", "dep:futures-channel", "dep:rayon"]
 download-lib = ["aic-sdk-sys/download-lib"]
 download-model = ["dep:serde", "dep:serde_json", "dep:sha2", "dep:ureq"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,9 +53,13 @@ serde_json = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
 
 [features]
-async-processor = ["dep:async-lock", "dep:futures-channel", "dep:rayon"]
+async = ["dep:async-lock", "dep:futures-channel", "dep:rayon"]
 download-lib = ["aic-sdk-sys/download-lib"]
 download-model = ["dep:serde", "dep:serde_json", "dep:sha2", "dep:ureq"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [[example]]
 name = "basic_usage"
@@ -68,4 +72,4 @@ path = "examples/benchmark.rs"
 [[example]]
 name = "parallel_async"
 path = "examples/parallel_async.rs"
-required-features = ["async-processor"]
+required-features = ["async"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,12 +34,12 @@ version.workspace = true
 
 [dependencies]
 aic-sdk-sys = { workspace = true }
-rayon = { workspace = true }
+rayon = { workspace = true, optional = true }
 serde = { workspace = true, optional = true, features = ["derive"] }
 serde_json = { workspace = true, optional = true }
 sha2 = { workspace = true, optional = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["rt", "sync"] }
+tokio = { workspace = true, features = ["rt", "sync"], optional = true }
 ureq = { workspace = true, optional = true, features = ["rustls"] }
 
 [dev-dependencies]
@@ -50,6 +50,7 @@ serde_json = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
 
 [features]
+async-processor = ["dep:tokio", "dep:rayon"]
 download-lib = ["aic-sdk-sys/download-lib"]
 download-model = ["dep:serde", "dep:serde_json", "dep:sha2", "dep:ureq"]
 
@@ -64,3 +65,4 @@ path = "examples/benchmark.rs"
 [[example]]
 name = "parallel_async"
 path = "examples/parallel_async.rs"
+required-features = ["async-processor"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,12 @@ version = "0.17.1"
 
 [workspace.dependencies]
 aic-sdk-sys = { version = "0.17.1", path = "aic-sdk-sys" }
+rayon = "1"
 serde = { version = "1.0" }
 serde_json = { version = "1.0" }
 sha2 = { version = "0.10" }
 thiserror = "2.0"
+tokio = { version = "1" }
 ureq = { version = "3.1", default-features = false }
 
 [package]
@@ -32,17 +34,20 @@ version.workspace = true
 
 [dependencies]
 aic-sdk-sys = { workspace = true }
+rayon = { workspace = true }
 serde = { workspace = true, optional = true, features = ["derive"] }
 serde_json = { workspace = true, optional = true }
 sha2 = { workspace = true, optional = true }
 thiserror = { workspace = true }
+tokio = { workspace = true, features = ["sync", "rt"] }
 ureq = { workspace = true, optional = true, features = ["rustls"] }
 
 [dev-dependencies]
 approx = "0.5"
 audio-file = "0.4.1"
+futures = "0.3"
 serde_json = { workspace = true }
-tokio = { version = "1.49", features = ["macros", "rt-multi-thread", "sync", "time"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
 
 [features]
 download-lib = ["aic-sdk-sys/download-lib"]
@@ -55,3 +60,7 @@ path = "examples/basic_usage.rs"
 [[example]]
 name = "benchmark"
 path = "examples/benchmark.rs"
+
+[[example]]
+name = "parallel_async"
+path = "examples/parallel_async.rs"

--- a/README.md
+++ b/README.md
@@ -210,12 +210,12 @@ if vad_ctx.is_speech_detected() {
 
 ### Async Processing
 
-Enable the `async-processor` feature to use [`ProcessorAsync`], which offloads
+Enable the `async` feature to use [`ProcessorAsync`], which offloads
 processing to a background thread pool and returns a future. The implementation
 is runtime-agnostic and works on any executor (tokio, smol, async-std, ...).
 
 ```bash
-cargo add aic-sdk --features async-processor
+cargo add aic-sdk --features async
 ```
 
 ```rust,ignore
@@ -243,7 +243,7 @@ See the example files for complete working examples:
 - [`examples/basic_usage.rs`](examples/basic_usage.rs) - Basic usage example
 - [`examples/build-time-download`](examples/build-time-download) - Download and embed models at compile-time
 - [`examples/benchmark.rs`](examples/benchmark.rs) - Run multiple processor instances concurrently until the real-time requirements are not met
-- [`examples/parallel_async.rs`](examples/parallel_async.rs) - Async processing with `ProcessorAsync` across multiple instances (requires `async-processor`)
+- [`examples/parallel_async.rs`](examples/parallel_async.rs) - Async processing with `ProcessorAsync` across multiple instances (requires `async`)
 
 Run examples with:
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Load the embedded model (or download manually at https://artifacts.ai-coustics.io/)
     let model = Model::from_buffer(MODEL)?;
-    
+
     // Get optimal configuration based on the selected model
     let config = ProcessorConfig::optimal(&model).with_num_channels(2);
 
@@ -66,6 +66,7 @@ println!("Compatible model version: {}", aic_sdk::get_compatible_model_version()
 Download models and find available IDs at [artifacts.ai-coustics.io](https://artifacts.ai-coustics.io/).
 
 #### Load from File
+
 ```rust,ignore
 use aic_sdk::Model;
 
@@ -73,6 +74,7 @@ let model = Model::from_file("path/to/model.aicmodel")?;
 ```
 
 #### Embed at Compile Time
+
 ```rust,ignore
 use aic_sdk::{Model, include_model};
 
@@ -81,6 +83,7 @@ let model = Model::from_buffer(MODEL)?;
 ```
 
 #### Download from CDN
+
 Enable the `download-model` feature:
 
 ```bash
@@ -205,14 +208,45 @@ if vad_ctx.is_speech_detected() {
 }
 ```
 
+### Async Processing
+
+Enable the `async-processor` feature to use [`ProcessorAsync`], which offloads
+processing to a background thread pool and returns a future. The implementation
+is runtime-agnostic and works on any executor (tokio, smol, async-std, ...).
+
+```bash
+cargo add aic-sdk --features async-processor
+```
+
+```rust,ignore
+use aic_sdk::{Model, ProcessorAsync, ProcessorConfig};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let license_key = std::env::var("AIC_SDK_LICENSE")?;
+    let model = Model::from_file("path/to/model.aicmodel")?;
+    let config = ProcessorConfig::optimal(&model).with_num_channels(2);
+
+    let processor = ProcessorAsync::with_config(&model, &license_key, &config).await?;
+
+    // The async API takes ownership of the buffer and returns it back.
+    let audio = vec![0.0f32; config.num_channels as usize * config.num_frames];
+    let audio = processor.process_interleaved(audio).await?;
+    Ok(())
+}
+```
+
 ## Examples
 
 See the example files for complete working examples:
+
 - [`examples/basic_usage.rs`](examples/basic_usage.rs) - Basic usage example
 - [`examples/build-time-download`](examples/build-time-download) - Download and embed models at compile-time
 - [`examples/benchmark.rs`](examples/benchmark.rs) - Run multiple processor instances concurrently until the real-time requirements are not met
+- [`examples/parallel_async.rs`](examples/parallel_async.rs) - Async processing with `ProcessorAsync` across multiple instances (requires `async-processor`)
 
 Run examples with:
+
 ```bash
 export AIC_SDK_LICENSE="your_license_key_here"
 cargo run --example basic_usage --features download-lib,download-model

--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ if vad_ctx.is_speech_detected() {
 Enable the `async` feature to use [`ProcessorAsync`], which offloads
 processing to a background thread pool and returns a future. The implementation
 is runtime-agnostic and works on any executor (tokio, smol, async-std, ...).
+The pool defaults to one thread per logical CPU; override with the
+`AIC_NUM_THREADS` environment variable.
 
 ```bash
 cargo add aic-sdk --features async

--- a/examples/basic_usage.rs
+++ b/examples/basic_usage.rs
@@ -1,15 +1,6 @@
-#![cfg_attr(not(feature = "download-model"), allow(dead_code, unused_imports))]
-
-#[cfg(feature = "download-model")]
 use aic_sdk::{Model, Processor, ProcessorConfig, ProcessorParameter, VadParameter};
 use std::env;
 
-#[cfg(not(feature = "download-model"))]
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    Err("Enable the `download-model` feature to run this example.".into())
-}
-
-#[cfg(feature = "download-model")]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Display library version
     println!("ai-coustics SDK version: {}", aic_sdk::get_sdk_version());

--- a/examples/parallel_async.rs
+++ b/examples/parallel_async.rs
@@ -1,0 +1,125 @@
+// Demonstrates that multiple `ProcessorAsync` instances genuinely run in
+// parallel when awaited concurrently.
+//
+// Each processor records its own wall-clock processing time.  If they ran
+// sequentially, the total elapsed time would be roughly `N × per-processor time`.
+// When running in parallel the total time is close to the slowest
+// single processor, which is what we verify and print.
+
+#![cfg_attr(not(feature = "download-model"), allow(dead_code, unused_imports))]
+
+#[cfg(feature = "download-model")]
+use aic_sdk::{Model, ProcessorAsync, ProcessorConfig};
+use std::time::Instant;
+
+const MODEL: &str = "quail-vf-2.1-l-16khz";
+const NUM_PROCESSORS: usize = 4;
+// Number of process calls per processor – enough to make timing visible.
+const ITERATIONS: usize = 50;
+
+#[cfg(not(feature = "download-model"))]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    Err("Enable the `download-model` feature to run this example.".into())
+}
+
+#[cfg(feature = "download-model")]
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("ai-coustics SDK version: {}", aic_sdk::get_sdk_version());
+
+    let license = std::env::var("AIC_SDK_LICENSE").expect("AIC_SDK_LICENSE not set");
+
+    let model_path = Model::download(MODEL, "target")?;
+    let model = Model::from_file(&model_path)?;
+    println!("Model loaded from {}", model_path.display());
+
+    let config = ProcessorConfig::optimal(&model);
+    println!(
+        "Config: {} Hz, {} frames/buffer, {} channel(s)\n",
+        config.sample_rate, config.num_frames, config.num_channels
+    );
+
+    // Build all processors up front
+    let processors = futures::future::try_join_all(
+        (0..NUM_PROCESSORS).map(|_| ProcessorAsync::with_config(&model, &license, &config)),
+    )
+    .await?;
+
+    println!(
+        "Running {} processors × {} iterations each",
+        NUM_PROCESSORS, ITERATIONS
+    );
+
+    let buf_len = config.num_channels as usize * config.num_frames;
+
+    // Sequential baseline
+    let sequential_start = Instant::now();
+    for p in &processors {
+        let mut audio = vec![0.0f32; buf_len];
+        for _ in 0..ITERATIONS {
+            p.process_interleaved(&mut audio).await?;
+        }
+    }
+    let sequential_elapsed = sequential_start.elapsed();
+
+    println!(
+        "Sequential total:  {:>8.1} ms",
+        sequential_elapsed.as_secs_f64() * 1000.0
+    );
+
+    // Parallel run
+    let parallel_start = Instant::now();
+
+    let tasks: Vec<_> = processors
+        .iter()
+        .map(|p| {
+            let config = config.clone();
+            async move {
+                let mut audio = vec![0.0f32; config.num_channels as usize * config.num_frames];
+                let t0 = Instant::now();
+                for _ in 0..ITERATIONS {
+                    p.process_interleaved(&mut audio).await?;
+                }
+                Ok::<_, aic_sdk::AicError>(t0.elapsed())
+            }
+        })
+        .collect();
+
+    let results = futures::future::try_join_all(tasks).await?;
+    let parallel_elapsed = parallel_start.elapsed();
+
+    for (id, elapsed) in results.iter().enumerate() {
+        println!(
+            "  Processor {:>2} finished in {:>8.1} ms",
+            id + 1,
+            elapsed.as_secs_f64() * 1000.0,
+        );
+    }
+
+    let max_individual = results.iter().max().copied().unwrap_or_default();
+
+    println!(
+        "\nParallel total:      {:>8.1} ms",
+        parallel_elapsed.as_secs_f64() * 1000.0
+    );
+    println!(
+        "Slowest processor:   {:>8.1} ms",
+        max_individual.as_secs_f64() * 1000.0,
+    );
+
+    let speedup = sequential_elapsed.as_secs_f64() / parallel_elapsed.as_secs_f64();
+    println!(
+        "\nSpeedup vs sequential: {:.2}x  (ideal ≈ {}x)",
+        speedup, NUM_PROCESSORS
+    );
+    println!(
+        "{}",
+        if speedup > 1.5 {
+            "Parallel execution confirmed."
+        } else {
+            "Warning: low speedup – your system may not have enough CPU cores, or the model may be too small for parallelism to be visible."
+        }
+    );
+
+    Ok(())
+}

--- a/examples/parallel_async.rs
+++ b/examples/parallel_async.rs
@@ -57,7 +57,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     for p in &processors {
         let mut audio = vec![0.0f32; buf_len];
         for _ in 0..ITERATIONS {
-            p.process_interleaved(&mut audio).await?;
+            audio = p.process_interleaved(audio).await?;
         }
     }
     let sequential_elapsed = sequential_start.elapsed();
@@ -78,7 +78,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 let mut audio = vec![0.0f32; config.num_channels as usize * config.num_frames];
                 let t0 = Instant::now();
                 for _ in 0..ITERATIONS {
-                    p.process_interleaved(&mut audio).await?;
+                    audio = p.process_interleaved(audio).await?;
                 }
                 Ok::<_, aic_sdk::AicError>(t0.elapsed())
             }

--- a/examples/parallel_async.rs
+++ b/examples/parallel_async.rs
@@ -6,9 +6,6 @@
 // When running in parallel the total time is close to the slowest
 // single processor, which is what we verify and print.
 
-#![cfg_attr(not(feature = "download-model"), allow(dead_code, unused_imports))]
-
-#[cfg(feature = "download-model")]
 use aic_sdk::{Model, ProcessorAsync, ProcessorConfig};
 use std::time::Instant;
 
@@ -17,12 +14,6 @@ const NUM_PROCESSORS: usize = 4;
 // Number of process calls per processor – enough to make timing visible.
 const ITERATIONS: usize = 50;
 
-#[cfg(not(feature = "download-model"))]
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    Err("Enable the `download-model` feature to run this example.".into())
-}
-
-#[cfg(feature = "download-model")]
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("ai-coustics SDK version: {}", aic_sdk::get_sdk_version());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,11 +7,13 @@ mod download;
 mod error;
 mod model;
 mod processor;
+mod processor_async;
 mod vad;
 
 pub use error::*;
 pub use model::*;
 pub use processor::*;
+pub use processor_async::*;
 pub use vad::*;
 
 /// Returns the version of the ai-coustics SDK library.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 use aic_sdk_sys::{aic_get_compatible_model_version, aic_get_sdk_version, aic_set_sdk_wrapper_id};
 use std::ffi::CStr;
 
@@ -7,14 +8,14 @@ mod download;
 mod error;
 mod model;
 mod processor;
-#[cfg(feature = "async-processor")]
+#[cfg(feature = "async")]
 mod processor_async;
 mod vad;
 
 pub use error::*;
 pub use model::*;
 pub use processor::*;
-#[cfg(feature = "async-processor")]
+#[cfg(feature = "async")]
 pub use processor_async::*;
 pub use vad::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,12 +7,14 @@ mod download;
 mod error;
 mod model;
 mod processor;
+#[cfg(feature = "async-processor")]
 mod processor_async;
 mod vad;
 
 pub use error::*;
 pub use model::*;
 pub use processor::*;
+#[cfg(feature = "async-processor")]
 pub use processor_async::*;
 pub use vad::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![doc = include_str!("../README.md")]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 use aic_sdk_sys::{aic_get_compatible_model_version, aic_get_sdk_version, aic_set_sdk_wrapper_id};
 use std::ffi::CStr;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,17 @@
 #![doc = include_str!("../README.md")]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 use aic_sdk_sys::{aic_get_compatible_model_version, aic_get_sdk_version, aic_set_sdk_wrapper_id};
 use std::ffi::CStr;
 
 #[cfg(feature = "download-model")]
+#[cfg_attr(docsrs, doc(cfg(feature = "download-model")))]
 mod download;
 mod error;
 mod model;
 mod processor;
 #[cfg(feature = "async")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async")))]
 mod processor_async;
 mod vad;
 
@@ -16,6 +19,7 @@ pub use error::*;
 pub use model::*;
 pub use processor::*;
 #[cfg(feature = "async")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async")))]
 pub use processor_async::*;
 pub use vad::*;
 

--- a/src/processor_async.rs
+++ b/src/processor_async.rs
@@ -46,6 +46,8 @@ fn pool() -> &'static rayon::ThreadPool {
 /// ```
 pub struct ProcessorAsync {
     inner: Arc<Mutex<Processor<'static>>>,
+    processor_context: Arc<ProcessorContext>,
+    vad_context: Arc<VadContext>,
 }
 
 impl ProcessorAsync {
@@ -54,8 +56,12 @@ impl ProcessorAsync {
     /// See [`Processor::new`] for details.
     pub fn new(model: &Model<'static>, license_key: &str) -> Result<Self, AicError> {
         let processor = Processor::new(model, license_key)?;
+        let processor_context = Arc::new(processor.processor_context());
+        let vad_context = Arc::new(processor.vad_context());
         Ok(Self {
             inner: Arc::new(Mutex::new(processor)),
+            processor_context,
+            vad_context,
         })
     }
 
@@ -90,75 +96,134 @@ impl ProcessorAsync {
 
     /// Processes audio with interleaved channel data.
     ///
+    /// This is a convenience wrapper around
+    /// [`ProcessorAsync::process_interleaved_owned`]. It copies `audio` into an
+    /// owned buffer before processing and copies the processed samples back before
+    /// returning.
+    ///
     /// See [`Processor::process_interleaved`] for details on the memory layout.
     pub async fn process_interleaved(&self, audio: &mut [f32]) -> Result<(), AicError> {
+        let buf = self.process_interleaved_owned(audio.to_vec()).await?;
+        audio.copy_from_slice(&buf);
+        Ok(())
+    }
+
+    /// Processes owned audio with interleaved channel data.
+    ///
+    /// This method takes ownership of `audio`, moves it to a background processing
+    /// thread, and returns the processed buffer. Use this when the caller can hand
+    /// over ownership and wants to avoid the extra copy-back performed by
+    /// [`ProcessorAsync::process_interleaved`].
+    ///
+    /// See [`Processor::process_interleaved`] for details on the memory layout.
+    pub async fn process_interleaved_owned(
+        &self,
+        mut audio: Vec<f32>,
+    ) -> Result<Vec<f32>, AicError> {
         let inner = Arc::clone(&self.inner);
-        let mut buf = audio.to_vec();
         let (tx, rx) = tokio::sync::oneshot::channel();
         let mut processor = inner.lock_owned().await;
         pool().spawn(move || {
-            let result = processor.process_interleaved(&mut buf).map(|_| buf);
+            let result = processor.process_interleaved(&mut audio).map(|_| audio);
             let _ = tx.send(result);
         });
-        rx.await
-            .expect("Rayon worker dropped")
-            .map(|buf| audio.copy_from_slice(&buf))
+        rx.await.expect("Rayon worker dropped")
     }
 
     /// Processes audio with separate buffers for each channel (planar layout).
+    ///
+    /// This is a convenience wrapper around [`ProcessorAsync::process_planar_owned`].
+    /// It copies each channel into an owned buffer before processing and copies the
+    /// processed samples back before returning.
     ///
     /// See [`Processor::process_planar`] for details on the memory layout.
     pub async fn process_planar<V: AsMut<[f32]> + AsRef<[f32]>>(
         &self,
         audio: &mut [V],
     ) -> Result<(), AicError> {
+        let buf = audio.iter().map(|ch| ch.as_ref().to_vec()).collect();
+        let buf = self.process_planar_owned(buf).await?;
+        for (dst, src) in audio.iter_mut().zip(buf.iter()) {
+            dst.as_mut().copy_from_slice(src);
+        }
+        Ok(())
+    }
+
+    /// Processes owned audio with separate buffers for each channel (planar layout).
+    ///
+    /// This method takes ownership of `audio`, moves it to a background processing
+    /// thread, and returns the processed channel buffers. Use this when the caller
+    /// can hand over ownership and wants to avoid the extra copy-back performed by
+    /// [`ProcessorAsync::process_planar`].
+    ///
+    /// See [`Processor::process_planar`] for details on the memory layout.
+    pub async fn process_planar_owned(
+        &self,
+        mut audio: Vec<Vec<f32>>,
+    ) -> Result<Vec<Vec<f32>>, AicError> {
         let inner = Arc::clone(&self.inner);
-        let mut buf: Vec<Vec<f32>> = audio.iter().map(|ch| ch.as_ref().to_vec()).collect();
         let (tx, rx) = tokio::sync::oneshot::channel();
         let mut processor = inner.lock_owned().await;
         pool().spawn(move || {
-            let result = processor.process_planar(&mut buf).map(|_| buf);
+            let result = processor.process_planar(&mut audio).map(|_| audio);
             let _ = tx.send(result);
         });
-        rx.await
-            .expect("Rayon worker dropped")
-            .map(|buf| {
-                for (dst, src) in audio.iter_mut().zip(buf.iter()) {
-                    dst.as_mut().copy_from_slice(src);
-                }
-            })
+        rx.await.expect("Rayon worker dropped")
     }
 
     /// Processes audio with sequential channel data.
     ///
+    /// This is a convenience wrapper around
+    /// [`ProcessorAsync::process_sequential_owned`]. It copies `audio` into an
+    /// owned buffer before processing and copies the processed samples back before
+    /// returning.
+    ///
     /// See [`Processor::process_sequential`] for details on the memory layout.
     pub async fn process_sequential(&self, audio: &mut [f32]) -> Result<(), AicError> {
+        let buf = self.process_sequential_owned(audio.to_vec()).await?;
+        audio.copy_from_slice(&buf);
+        Ok(())
+    }
+
+    /// Processes owned audio with sequential channel data.
+    ///
+    /// This method takes ownership of `audio`, moves it to a background processing
+    /// thread, and returns the processed buffer. Use this when the caller can hand
+    /// over ownership and wants to avoid the extra copy-back performed by
+    /// [`ProcessorAsync::process_sequential`].
+    ///
+    /// See [`Processor::process_sequential`] for details on the memory layout.
+    pub async fn process_sequential_owned(
+        &self,
+        mut audio: Vec<f32>,
+    ) -> Result<Vec<f32>, AicError> {
         let inner = Arc::clone(&self.inner);
-        let mut buf = audio.to_vec();
         let (tx, rx) = tokio::sync::oneshot::channel();
         let mut processor = inner.lock_owned().await;
         pool().spawn(move || {
-            let result = processor.process_sequential(&mut buf).map(|_| buf);
+            let result = processor.process_sequential(&mut audio).map(|_| audio);
             let _ = tx.send(result);
         });
-        rx.await
-            .expect("Rayon worker dropped")
-            .map(|buf| audio.copy_from_slice(&buf))
+        rx.await.expect("Rayon worker dropped")
     }
 
-    /// Creates a [`ProcessorContext`] for real-time parameter control.
+    /// Returns a [`ProcessorContext`] for real-time parameter control.
+    ///
+    /// The handle is created once at construction time and shared across calls;
+    /// every caller gets a clone of the same underlying context.
     ///
     /// See [`Processor::processor_context`] for details.
-    pub async fn processor_context(&self) -> ProcessorContext {
-        let processor = self.inner.lock().await;
-        processor.processor_context()
+    pub fn processor_context(&self) -> Arc<ProcessorContext> {
+        Arc::clone(&self.processor_context)
     }
 
-    /// Creates a [`VadContext`] for voice activity detection.
+    /// Returns a [`VadContext`] for voice activity detection.
+    ///
+    /// The handle is created once at construction time and shared across calls;
+    /// every caller gets a clone of the same underlying context.
     ///
     /// See [`Processor::vad_context`] for details.
-    pub async fn vad_context(&self) -> VadContext {
-        let processor = self.inner.lock().await;
-        processor.vad_context()
+    pub fn vad_context(&self) -> Arc<VadContext> {
+        Arc::clone(&self.vad_context)
     }
 }

--- a/src/processor_async.rs
+++ b/src/processor_async.rs
@@ -1,0 +1,164 @@
+use crate::{AicError, Model, Processor, ProcessorConfig, ProcessorContext, VadContext};
+use std::sync::{Arc, OnceLock};
+use tokio::sync::Mutex;
+
+static RAYON_POOL: OnceLock<rayon::ThreadPool> = OnceLock::new();
+
+fn pool() -> &'static rayon::ThreadPool {
+    RAYON_POOL.get_or_init(|| {
+        let num_threads = std::env::var("AIC_NUM_THREADS")
+            .ok()
+            .and_then(|s| s.parse::<usize>().ok())
+            .filter(|&n| n > 0)
+            .unwrap_or_else(|| {
+                std::thread::available_parallelism()
+                    .map(|n| n.get())
+                    .unwrap_or(1)
+            });
+
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(num_threads)
+            .thread_name(|i| format!("aic-processing-thread-{i}"))
+            .build()
+            .expect("failed to build aic thread-pool")
+    })
+}
+
+/// An async wrapper around [`Processor`] for use in async/await contexts.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use aic_sdk::{Model, ProcessorAsync, ProcessorConfig};
+/// #[tokio::main]
+/// async fn main() -> Result<(), aic_sdk::AicError> {
+///     let license_key = std::env::var("AIC_SDK_LICENSE").unwrap();
+///     let model = Model::from_file("/path/to/model.aicmodel")?;
+///     let config = ProcessorConfig::optimal(&model).with_num_channels(2);
+///
+///     let processor = ProcessorAsync::new(&model, &license_key)?;
+///     processor.initialize(&config).await?;
+///
+///     let mut audio = vec![0.0f32; config.num_channels as usize * config.num_frames];
+///     processor.process_interleaved(&mut audio).await?;
+///     Ok(())
+/// }
+/// ```
+pub struct ProcessorAsync {
+    inner: Arc<Mutex<Processor<'static>>>,
+}
+
+impl ProcessorAsync {
+    /// Creates a new async audio enhancement processor instance.
+    ///
+    /// See [`Processor::new`] for details.
+    pub fn new(model: &Model<'static>, license_key: &str) -> Result<Self, AicError> {
+        let processor = Processor::new(model, license_key)?;
+        Ok(Self {
+            inner: Arc::new(Mutex::new(processor)),
+        })
+    }
+
+    /// Creates a new async processor and initializes it with the given configuration.
+    ///
+    /// This is a convenience method combining [`ProcessorAsync::new`] and
+    /// [`ProcessorAsync::initialize`].
+    pub async fn with_config(
+        model: &Model<'static>,
+        license_key: &str,
+        config: &ProcessorConfig,
+    ) -> Result<Self, AicError> {
+        let this = Self::new(model, license_key)?;
+        this.initialize(config).await?;
+        Ok(this)
+    }
+
+    /// Initializes the processor with the given configuration.
+    ///
+    /// See [`Processor::initialize`] for details.
+    ///
+    /// # Warning
+    /// This allocates memory internally. Do not call from latency-sensitive paths.
+    pub async fn initialize(&self, config: &ProcessorConfig) -> Result<(), AicError> {
+        let inner = Arc::clone(&self.inner);
+        let config = config.clone();
+        let mut processor = inner.lock_owned().await;
+        tokio::task::spawn_blocking(move || processor.initialize(&config))
+            .await
+            .expect("spawn_blocking task panicked")
+    }
+
+    /// Processes audio with interleaved channel data.
+    ///
+    /// See [`Processor::process_interleaved`] for details on the memory layout.
+    pub async fn process_interleaved(&self, audio: &mut [f32]) -> Result<(), AicError> {
+        let inner = Arc::clone(&self.inner);
+        let mut buf = audio.to_vec();
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let mut processor = inner.lock_owned().await;
+        pool().spawn(move || {
+            let result = processor.process_interleaved(&mut buf).map(|_| buf);
+            let _ = tx.send(result);
+        });
+        rx.await
+            .expect("Rayon worker dropped")
+            .map(|buf| audio.copy_from_slice(&buf))
+    }
+
+    /// Processes audio with separate buffers for each channel (planar layout).
+    ///
+    /// See [`Processor::process_planar`] for details on the memory layout.
+    pub async fn process_planar<V: AsMut<[f32]> + AsRef<[f32]>>(
+        &self,
+        audio: &mut [V],
+    ) -> Result<(), AicError> {
+        let inner = Arc::clone(&self.inner);
+        let mut buf: Vec<Vec<f32>> = audio.iter().map(|ch| ch.as_ref().to_vec()).collect();
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let mut processor = inner.lock_owned().await;
+        pool().spawn(move || {
+            let result = processor.process_planar(&mut buf).map(|_| buf);
+            let _ = tx.send(result);
+        });
+        rx.await
+            .expect("Rayon worker dropped")
+            .map(|buf| {
+                for (dst, src) in audio.iter_mut().zip(buf.iter()) {
+                    dst.as_mut().copy_from_slice(src);
+                }
+            })
+    }
+
+    /// Processes audio with sequential channel data.
+    ///
+    /// See [`Processor::process_sequential`] for details on the memory layout.
+    pub async fn process_sequential(&self, audio: &mut [f32]) -> Result<(), AicError> {
+        let inner = Arc::clone(&self.inner);
+        let mut buf = audio.to_vec();
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let mut processor = inner.lock_owned().await;
+        pool().spawn(move || {
+            let result = processor.process_sequential(&mut buf).map(|_| buf);
+            let _ = tx.send(result);
+        });
+        rx.await
+            .expect("Rayon worker dropped")
+            .map(|buf| audio.copy_from_slice(&buf))
+    }
+
+    /// Creates a [`ProcessorContext`] for real-time parameter control.
+    ///
+    /// See [`Processor::processor_context`] for details.
+    pub async fn processor_context(&self) -> ProcessorContext {
+        let processor = self.inner.lock().await;
+        processor.processor_context()
+    }
+
+    /// Creates a [`VadContext`] for voice activity detection.
+    ///
+    /// See [`Processor::vad_context`] for details.
+    pub async fn vad_context(&self) -> VadContext {
+        let processor = self.inner.lock().await;
+        processor.vad_context()
+    }
+}

--- a/src/processor_async.rs
+++ b/src/processor_async.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, OnceLock};
 
 static RAYON_POOL: OnceLock<rayon::ThreadPool> = OnceLock::new();
 
-fn pool() -> &'static rayon::ThreadPool {
+fn get_global_thread_pool() -> &'static rayon::ThreadPool {
     RAYON_POOL.get_or_init(|| {
         let num_threads = std::env::var("AIC_NUM_THREADS")
             .ok()
@@ -90,7 +90,7 @@ impl ProcessorAsync {
         let config = config.clone();
         let (tx, rx) = oneshot::channel();
         let mut processor = self.inner.lock_arc().await;
-        pool().spawn(move || {
+        get_global_thread_pool().spawn(move || {
             let _ = tx.send(processor.initialize(&config));
         });
         rx.await.expect("Rayon worker dropped")
@@ -105,7 +105,7 @@ impl ProcessorAsync {
     pub async fn process_interleaved(&self, mut audio: Vec<f32>) -> Result<Vec<f32>, AicError> {
         let (tx, rx) = oneshot::channel();
         let mut processor = self.inner.lock_arc().await;
-        pool().spawn(move || {
+        get_global_thread_pool().spawn(move || {
             let result = processor.process_interleaved(&mut audio).map(|_| audio);
             let _ = tx.send(result);
         });
@@ -124,7 +124,7 @@ impl ProcessorAsync {
     ) -> Result<Vec<Vec<f32>>, AicError> {
         let (tx, rx) = oneshot::channel();
         let mut processor = self.inner.lock_arc().await;
-        pool().spawn(move || {
+        get_global_thread_pool().spawn(move || {
             let result = processor.process_planar(&mut audio).map(|_| audio);
             let _ = tx.send(result);
         });
@@ -140,7 +140,7 @@ impl ProcessorAsync {
     pub async fn process_sequential(&self, mut audio: Vec<f32>) -> Result<Vec<f32>, AicError> {
         let (tx, rx) = oneshot::channel();
         let mut processor = self.inner.lock_arc().await;
-        pool().spawn(move || {
+        get_global_thread_pool().spawn(move || {
             let result = processor.process_sequential(&mut audio).map(|_| audio);
             let _ = tx.send(result);
         });

--- a/src/processor_async.rs
+++ b/src/processor_async.rs
@@ -1,6 +1,7 @@
 use crate::{AicError, Model, Processor, ProcessorConfig, ProcessorContext, VadContext};
+use async_lock::Mutex;
+use futures_channel::oneshot;
 use std::sync::{Arc, OnceLock};
-use tokio::sync::Mutex;
 
 static RAYON_POOL: OnceLock<rayon::ThreadPool> = OnceLock::new();
 
@@ -86,12 +87,13 @@ impl ProcessorAsync {
     /// # Warning
     /// This allocates memory internally. Do not call from latency-sensitive paths.
     pub async fn initialize(&self, config: &ProcessorConfig) -> Result<(), AicError> {
-        let inner = Arc::clone(&self.inner);
         let config = config.clone();
-        let mut processor = inner.lock_owned().await;
-        tokio::task::spawn_blocking(move || processor.initialize(&config))
-            .await
-            .expect("spawn_blocking task panicked")
+        let (tx, rx) = oneshot::channel();
+        let mut processor = self.inner.lock_arc().await;
+        pool().spawn(move || {
+            let _ = tx.send(processor.initialize(&config));
+        });
+        rx.await.expect("Rayon worker dropped")
     }
 
     /// Processes audio with interleaved channel data.
@@ -101,9 +103,8 @@ impl ProcessorAsync {
     ///
     /// See [`Processor::process_interleaved`] for details on the memory layout.
     pub async fn process_interleaved(&self, mut audio: Vec<f32>) -> Result<Vec<f32>, AicError> {
-        let inner = Arc::clone(&self.inner);
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        let mut processor = inner.lock_owned().await;
+        let (tx, rx) = oneshot::channel();
+        let mut processor = self.inner.lock_arc().await;
         pool().spawn(move || {
             let result = processor.process_interleaved(&mut audio).map(|_| audio);
             let _ = tx.send(result);
@@ -121,9 +122,8 @@ impl ProcessorAsync {
         &self,
         mut audio: Vec<Vec<f32>>,
     ) -> Result<Vec<Vec<f32>>, AicError> {
-        let inner = Arc::clone(&self.inner);
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        let mut processor = inner.lock_owned().await;
+        let (tx, rx) = oneshot::channel();
+        let mut processor = self.inner.lock_arc().await;
         pool().spawn(move || {
             let result = processor.process_planar(&mut audio).map(|_| audio);
             let _ = tx.send(result);
@@ -138,9 +138,8 @@ impl ProcessorAsync {
     ///
     /// See [`Processor::process_sequential`] for details on the memory layout.
     pub async fn process_sequential(&self, mut audio: Vec<f32>) -> Result<Vec<f32>, AicError> {
-        let inner = Arc::clone(&self.inner);
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        let mut processor = inner.lock_owned().await;
+        let (tx, rx) = oneshot::channel();
+        let mut processor = self.inner.lock_arc().await;
         pool().spawn(move || {
             let result = processor.process_sequential(&mut audio).map(|_| audio);
             let _ = tx.send(result);

--- a/src/processor_async.rs
+++ b/src/processor_async.rs
@@ -21,11 +21,18 @@ fn get_global_thread_pool() -> &'static rayon::ThreadPool {
             .num_threads(num_threads)
             .thread_name(|i| format!("aic-processing-thread-{i}"))
             .build()
-            .expect("failed to build aic thread-pool")
+            .expect("failed to build aic thread pool")
     })
 }
 
-/// An async wrapper around [`Processor`] for use in async/await contexts.
+/// A wrapper around [`Processor`] for use in async contexts.
+///
+/// # Threading
+///
+/// Processing runs on a background thread pool shared across all
+/// [`ProcessorAsync`] instances. The pool defaults to one thread per logical
+/// CPU. Override with the `AIC_NUM_THREADS` environment variable, which is
+/// read once on first use.
 ///
 /// # Example
 ///
@@ -47,8 +54,6 @@ fn get_global_thread_pool() -> &'static rayon::ThreadPool {
 /// ```
 pub struct ProcessorAsync {
     inner: Arc<Mutex<Processor<'static>>>,
-    processor_context: Arc<ProcessorContext>,
-    vad_context: Arc<VadContext>,
 }
 
 impl ProcessorAsync {
@@ -57,12 +62,8 @@ impl ProcessorAsync {
     /// See [`Processor::new`] for details.
     pub fn new(model: &Model<'static>, license_key: &str) -> Result<Self, AicError> {
         let processor = Processor::new(model, license_key)?;
-        let processor_context = Arc::new(processor.processor_context());
-        let vad_context = Arc::new(processor.vad_context());
         Ok(Self {
             inner: Arc::new(Mutex::new(processor)),
-            processor_context,
-            vad_context,
         })
     }
 
@@ -149,21 +150,15 @@ impl ProcessorAsync {
 
     /// Returns a [`ProcessorContext`] for real-time parameter control.
     ///
-    /// The handle is created once at construction time and shared across calls;
-    /// every caller gets a clone of the same underlying context.
-    ///
     /// See [`Processor::processor_context`] for details.
-    pub fn processor_context(&self) -> Arc<ProcessorContext> {
-        Arc::clone(&self.processor_context)
+    pub async fn processor_context(&self) -> ProcessorContext {
+        self.inner.lock().await.processor_context()
     }
 
     /// Returns a [`VadContext`] for voice activity detection.
     ///
-    /// The handle is created once at construction time and shared across calls;
-    /// every caller gets a clone of the same underlying context.
-    ///
     /// See [`Processor::vad_context`] for details.
-    pub fn vad_context(&self) -> Arc<VadContext> {
-        Arc::clone(&self.vad_context)
+    pub async fn vad_context(&self) -> VadContext {
+        self.inner.lock().await.vad_context()
     }
 }

--- a/src/processor_async.rs
+++ b/src/processor_async.rs
@@ -40,7 +40,7 @@ fn pool() -> &'static rayon::ThreadPool {
 ///     processor.initialize(&config).await?;
 ///
 ///     let mut audio = vec![0.0f32; config.num_channels as usize * config.num_frames];
-///     processor.process_interleaved(&mut audio).await?;
+///     let audio = processor.process_interleaved(audio).await?;
 ///     Ok(())
 /// }
 /// ```
@@ -96,30 +96,11 @@ impl ProcessorAsync {
 
     /// Processes audio with interleaved channel data.
     ///
-    /// This is a convenience wrapper around
-    /// [`ProcessorAsync::process_interleaved_owned`]. It copies `audio` into an
-    /// owned buffer before processing and copies the processed samples back before
-    /// returning.
-    ///
-    /// See [`Processor::process_interleaved`] for details on the memory layout.
-    pub async fn process_interleaved(&self, audio: &mut [f32]) -> Result<(), AicError> {
-        let buf = self.process_interleaved_owned(audio.to_vec()).await?;
-        audio.copy_from_slice(&buf);
-        Ok(())
-    }
-
-    /// Processes owned audio with interleaved channel data.
-    ///
     /// This method takes ownership of `audio`, moves it to a background processing
-    /// thread, and returns the processed buffer. Use this when the caller can hand
-    /// over ownership and wants to avoid the extra copy-back performed by
-    /// [`ProcessorAsync::process_interleaved`].
+    /// thread, and returns the processed buffer.
     ///
     /// See [`Processor::process_interleaved`] for details on the memory layout.
-    pub async fn process_interleaved_owned(
-        &self,
-        mut audio: Vec<f32>,
-    ) -> Result<Vec<f32>, AicError> {
+    pub async fn process_interleaved(&self, mut audio: Vec<f32>) -> Result<Vec<f32>, AicError> {
         let inner = Arc::clone(&self.inner);
         let (tx, rx) = tokio::sync::oneshot::channel();
         let mut processor = inner.lock_owned().await;
@@ -132,32 +113,11 @@ impl ProcessorAsync {
 
     /// Processes audio with separate buffers for each channel (planar layout).
     ///
-    /// This is a convenience wrapper around [`ProcessorAsync::process_planar_owned`].
-    /// It copies each channel into an owned buffer before processing and copies the
-    /// processed samples back before returning.
-    ///
-    /// See [`Processor::process_planar`] for details on the memory layout.
-    pub async fn process_planar<V: AsMut<[f32]> + AsRef<[f32]>>(
-        &self,
-        audio: &mut [V],
-    ) -> Result<(), AicError> {
-        let buf = audio.iter().map(|ch| ch.as_ref().to_vec()).collect();
-        let buf = self.process_planar_owned(buf).await?;
-        for (dst, src) in audio.iter_mut().zip(buf.iter()) {
-            dst.as_mut().copy_from_slice(src);
-        }
-        Ok(())
-    }
-
-    /// Processes owned audio with separate buffers for each channel (planar layout).
-    ///
     /// This method takes ownership of `audio`, moves it to a background processing
-    /// thread, and returns the processed channel buffers. Use this when the caller
-    /// can hand over ownership and wants to avoid the extra copy-back performed by
-    /// [`ProcessorAsync::process_planar`].
+    /// thread, and returns the processed channel buffers.
     ///
     /// See [`Processor::process_planar`] for details on the memory layout.
-    pub async fn process_planar_owned(
+    pub async fn process_planar(
         &self,
         mut audio: Vec<Vec<f32>>,
     ) -> Result<Vec<Vec<f32>>, AicError> {
@@ -173,30 +133,11 @@ impl ProcessorAsync {
 
     /// Processes audio with sequential channel data.
     ///
-    /// This is a convenience wrapper around
-    /// [`ProcessorAsync::process_sequential_owned`]. It copies `audio` into an
-    /// owned buffer before processing and copies the processed samples back before
-    /// returning.
-    ///
-    /// See [`Processor::process_sequential`] for details on the memory layout.
-    pub async fn process_sequential(&self, audio: &mut [f32]) -> Result<(), AicError> {
-        let buf = self.process_sequential_owned(audio.to_vec()).await?;
-        audio.copy_from_slice(&buf);
-        Ok(())
-    }
-
-    /// Processes owned audio with sequential channel data.
-    ///
     /// This method takes ownership of `audio`, moves it to a background processing
-    /// thread, and returns the processed buffer. Use this when the caller can hand
-    /// over ownership and wants to avoid the extra copy-back performed by
-    /// [`ProcessorAsync::process_sequential`].
+    /// thread, and returns the processed buffer.
     ///
     /// See [`Processor::process_sequential`] for details on the memory layout.
-    pub async fn process_sequential_owned(
-        &self,
-        mut audio: Vec<f32>,
-    ) -> Result<Vec<f32>, AicError> {
+    pub async fn process_sequential(&self, mut audio: Vec<f32>) -> Result<Vec<f32>, AicError> {
         let inner = Arc::clone(&self.inner);
         let (tx, rx) = tokio::sync::oneshot::channel();
         let mut processor = inner.lock_owned().await;


### PR DESCRIPTION
The goal here would be to use this async processor in the python version as well.

There are some things up for discussion.

The owned versions of the functions (e.g. `process_sequential_owned`) that take a Vector and return a new one, are added so we can move the Python Vector into the thread to have only one allocation instead of two. It is up for discussion though as it adds three more functions (only the sequential version is used there anyways).

The contexts are now always created in the async processor. This is not as nice in terms of telemetry, as we don't know if someone actually wanted to use the telemetry, but it makes the interface much better as we do not need to lock the processor anymore, just to get a pointer to the contexts. 