### PR TITLE
Add update_bearer_token for JWT licenses

### DIFF
--- a/aic-sdk-sys/include/aic.h
+++ b/aic-sdk-sys/include/aic.h
@@ -68,6 +68,10 @@ typedef enum AicErrorCode {
    */
   AIC_ERROR_CODE_LICENSE_EXPIRED = 52,
   /**
+   * Updating the token is only supported when both the original and new keys are JWT-form licenses.
+   */
+  AIC_ERROR_CODE_TOKEN_UPDATE_UNSUPPORTED = 53,
+  /**
    * The model file is invalid or corrupted. Verify the file is correct.
    */
   AIC_ERROR_CODE_MODEL_INVALID = 100,
@@ -753,6 +757,42 @@ enum AicErrorCode aic_processor_context_get_parameter(const struct AicProcessorC
  */
 enum AicErrorCode aic_processor_context_get_output_delay(const struct AicProcessorContext *context,
                                                          size_t *delay);
+
+/**
+ * Replaces the bearer token on a running processor.
+ *
+ * Use this when your license key is a JWT and needs to be refreshed
+ * before it expires. Calling this with a renewed token lets you stay authenticated
+ * without tearing down and recreating the processor: audio processing continues
+ * uninterrupted, the context handle stays valid, and the new token is used for all
+ * subsequent authentication against the ai-coustics backend.
+ *
+ * In-place updates are only supported when both the originally configured key and
+ * the new token are JWTs. Other license kinds
+ * cannot be swapped in this way. If either side is unsupported, the call returns
+ * `AIC_ERROR_CODE_TOKEN_UPDATE_UNSUPPORTED` and the existing token stays in use.
+ *
+ * Safe to call concurrently with `aic_processor_process()` on the originating
+ * processor.
+ *
+ * # Parameters
+ * - `context`: Processor context instance. Must not be NULL.
+ * - `token`: NULL-terminated string containing the new JWT. Must not be NULL.
+ *
+ * # Returns
+ * - `AIC_ERROR_CODE_SUCCESS`: Token replaced successfully
+ * - `AIC_ERROR_CODE_NULL_POINTER`: `context` or `token` is NULL
+ * - `AIC_ERROR_CODE_LICENSE_INVALID`: New token could not be parsed
+ * - `AIC_ERROR_CODE_TOKEN_UPDATE_UNSUPPORTED`: The original or new key does not support in-place updates
+ *
+ * # Safety
+ * - This function allocates memory and performs network-free cryptographic work. Avoid calling it from real-time audio threads.
+ * - Thread-safe: Can be called from any thread.
+ * - The `context` pointer must have been created by `aic_processor_context_create`.
+ * - `token` must point to a valid null-terminated UTF-8 string.
+ */
+enum AicErrorCode aic_processor_context_update_bearer_token(const struct AicProcessorContext *context,
+                                                            const char *token);
 
 /**
  * Creates a VAD context handle for thread-safe control APIs.

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,6 +33,10 @@ pub enum AicError {
     LicenseVersionUnsupported,
     #[error("License key has expired. Renew your license to continue.")]
     LicenseExpired,
+    #[error(
+        "Updating the token is only supported when both the original and new keys are JWT-form licenses."
+    )]
+    TokenUpdateUnsupported,
     #[error("The model file is invalid or corrupted. Verify the file is correct.")]
     ModelInvalid,
     #[error("The model file version is not compatible with this SDK version.")]
@@ -70,6 +74,7 @@ impl From<AicErrorCode::Type> for AicError {
             AIC_ERROR_CODE_LICENSE_FORMAT_INVALID => AicError::LicenseFormatInvalid,
             AIC_ERROR_CODE_LICENSE_VERSION_UNSUPPORTED => AicError::LicenseVersionUnsupported,
             AIC_ERROR_CODE_LICENSE_EXPIRED => AicError::LicenseExpired,
+            AIC_ERROR_CODE_TOKEN_UPDATE_UNSUPPORTED => AicError::TokenUpdateUnsupported,
             AIC_ERROR_CODE_MODEL_INVALID => AicError::ModelInvalid,
             AIC_ERROR_CODE_MODEL_VERSION_UNSUPPORTED => AicError::ModelVersionUnsupported,
             AIC_ERROR_CODE_MODEL_FILE_PATH_INVALID => AicError::ModelFilePathInvalid,

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -332,6 +332,61 @@ impl ProcessorContext {
         let error_code = unsafe { aic_processor_context_reset(self.as_const_ptr()) };
         handle_error(error_code)
     }
+
+    /// Replaces the bearer token on a running processor.
+    ///
+    /// Use this when your license key is a JWT and needs to be refreshed
+    /// before it expires. Calling this with a renewed token lets you stay
+    /// authenticated without tearing down and recreating the processor: audio
+    /// processing continues uninterrupted, the context handle stays valid, and
+    /// the new token is used for all subsequent authentication against the
+    /// ai-coustics backend.
+    ///
+    /// In-place updates are only supported when both the originally configured
+    /// key and the new token are JWTs. Other license kinds cannot be swapped
+    /// in this way. If either side is unsupported, the call returns
+    /// [`AicError::TokenUpdateUnsupported`] and the existing token stays in
+    /// use.
+    ///
+    /// Safe to call concurrently with audio processing on the originating
+    /// [`Processor`].
+    ///
+    /// # Arguments
+    ///
+    /// * `token` - The new JWT to use for backend requests.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(())` on success, [`AicError::LicenseFormatInvalid`] if the
+    /// new token cannot be parsed, or [`AicError::TokenUpdateUnsupported`] if
+    /// the original or new key does not support in-place updates.
+    ///
+    /// # Warning
+    ///
+    /// Do not call from real-time audio threads as this allocates memory and
+    /// performs cryptographic work.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use aic_sdk::{Model, Processor};
+    /// # let license_key = std::env::var("AIC_SDK_LICENSE").unwrap();
+    /// # let model = Model::from_file("/path/to/model.aicmodel").unwrap();
+    /// # let processor = Processor::new(&model, &license_key).unwrap();
+    /// # let processor_context = processor.processor_context();
+    /// # let new_jwt = std::env::var("AIC_SDK_LICENSE_REFRESHED").unwrap();
+    /// processor_context.update_bearer_token(&new_jwt).unwrap();
+    /// ```
+    pub fn update_bearer_token(&self, token: &str) -> Result<(), AicError> {
+        let c_token = CString::new(token).map_err(|_| AicError::LicenseFormatInvalid)?;
+        // SAFETY:
+        // - `self.as_const_ptr()` is a valid pointer to a live processor context.
+        // - `c_token` is a null-terminated CString owned for the duration of the call.
+        let error_code = unsafe {
+            aic_processor_context_update_bearer_token(self.as_const_ptr(), c_token.as_ptr())
+        };
+        handle_error(error_code)
+    }
 }
 
 impl Drop for ProcessorContext {


### PR DESCRIPTION
Mirrors the new aic_processor_context_update_bearer_token FFI and AIC_ERROR_CODE_TOKEN_UPDATE_UNSUPPORTED error code from the upstream C SDK, exposing them as ProcessorContext::update_bearer_token and AicError::TokenUpdateUnsupported on the Rust side.