### PR TITLE
Add analyze_file example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,11 @@ path = "examples/benchmark.rs"
 required-features = ["download-model"]
 
 [[example]]
+name = "analyze_file"
+path = "examples/analyze_file.rs"
+required-features = ["download-model"]
+
+[[example]]
 name = "parallel_async"
 path = "examples/parallel_async.rs"
 required-features = ["async", "download-model"]

--- a/examples/analyze_file.rs
+++ b/examples/analyze_file.rs
@@ -33,7 +33,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         STEP_SECONDS,
     );
 
-    let results = analyzer.analyze(&audio.samples, audio.sample_rate, None)?;
+    let step_samples = audio.sample_rate as usize * STEP_SECONDS;
+
+    let results = analyzer.analyze(&audio.samples, audio.sample_rate, Some(step_samples))?;
 
     println!();
     println!(" time | risk  | reverb | loud  | intf  | media | noise | loss");

--- a/examples/analyze_file.rs
+++ b/examples/analyze_file.rs
@@ -1,0 +1,94 @@
+use aic_sdk::{FileAnalyzer, Model};
+use std::{
+    env,
+    io::{Error, ErrorKind},
+    path::Path,
+};
+
+const MODEL: &str = "tyto-l-16khz";
+const STEP_SECONDS: usize = 5;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let audio_path = env::args().nth(1).ok_or_else(|| {
+        Error::new(
+            ErrorKind::InvalidInput,
+            "usage: cargo run --example analyze_file --features download-model -- <audio-file>",
+        )
+    })?;
+
+    let license = env::var("AIC_SDK_LICENSE").expect("AIC_SDK_LICENSE not set");
+
+    let audio = load_mono_audio(&audio_path)?;
+
+    let model_path = Model::download(MODEL, "target")?;
+    let model = Model::from_file(&model_path)?;
+    let mut analyzer = FileAnalyzer::new(&model, &license)?;
+
+    println!("Model loaded from {}", model_path.display());
+    println!(
+        "Analyzing {} at {} Hz, {} mono sample(s), {} second step",
+        audio_path,
+        audio.sample_rate,
+        audio.samples.len(),
+        STEP_SECONDS,
+    );
+
+    let results = analyzer.analyze(&audio.samples, audio.sample_rate, None)?;
+
+    println!();
+    println!(" time | risk  | reverb | loud  | intf  | media | noise | loss");
+    println!("------+-------+--------+-------+-------+-------+-------+------");
+    for (index, result) in results.iter().enumerate() {
+        println!(
+            "{:>4}s | {:>5.3} | {:>6.3} | {:>5.3} | {:>5.3} | {:>5.3} | {:>5.3} | {:>4.3}",
+            index * STEP_SECONDS,
+            result.risk_score,
+            result.speaker_reverb,
+            result.speaker_loudness,
+            result.interfering_speech,
+            result.media_speech,
+            result.noise,
+            result.packet_loss,
+        );
+    }
+
+    Ok(())
+}
+
+struct MonoAudio {
+    sample_rate: u32,
+    samples: Vec<f32>,
+}
+
+fn load_mono_audio(path: impl AsRef<Path>) -> Result<MonoAudio, Box<dyn std::error::Error>> {
+    let audio: audio_file::Audio<f32> = audio_file::read(path, audio_file::ReadConfig::default())?;
+    let num_channels = audio.num_channels as usize;
+
+    if num_channels == 0 {
+        return Err(Error::new(ErrorKind::InvalidData, "audio file has no channels").into());
+    }
+
+    if !audio.samples_interleaved.len().is_multiple_of(num_channels) {
+        return Err(Error::new(
+            ErrorKind::InvalidData,
+            "interleaved sample count is not divisible by channel count",
+        )
+        .into());
+    }
+
+    let samples = if num_channels == 1 {
+        audio.samples_interleaved
+    } else {
+        let scale = 1.0 / num_channels as f32;
+        audio
+            .samples_interleaved
+            .chunks_exact(num_channels)
+            .map(|frame| frame.iter().sum::<f32>() * scale)
+            .collect()
+    };
+
+    Ok(MonoAudio {
+        sample_rate: audio.sample_rate,
+        samples,
+    })
+}

--- a/src/file_analyzer.rs
+++ b/src/file_analyzer.rs
@@ -77,7 +77,7 @@ impl<'model, 'a> FileAnalyzer<'model, 'a> {
     /// * `audio` - Mono audio samples to analyze
     /// * `sample_rate` - Sample rate of `audio` in Hz
     /// * `step_samples` - Number of samples to advance between analysis results. Defaults to
-    /// the model's window size (no overlap in analysis windows) if `None`.
+    ///   the model's window size (no overlap in analysis windows) if `None`.
     ///
     /// # Returns
     ///


### PR DESCRIPTION
This PR adds a new example. Running `cargo run --example analyze_file --features download-lib,download-model ~/sample_5s.wav` outputs this:
```
Model loaded from target/tyto_l_16khz_yhlek4hc_v43.aicmodel
Analyzing /home/andy/sample_5s.wav at 16000 Hz, 80000 mono sample(s), 5 second step

 time | risk  | reverb | loud  | intf  | media | noise | loss
------+-------+--------+-------+-------+-------+-------+------
   0s | 0.180 |  0.133 | 0.623 | 0.000 | 0.024 | 0.591 | 0.001
```