### PR TITLE
rust-version = "1.91"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 homepage = "https://ai-coustics.com/sdk/"
 license = "Apache-2.0"
 repository = "https://github.com/ai-coustics/aic-sdk-rs"
+rust-version = "1.91"
 version = "0.20.0"
 
 [workspace.dependencies]
@@ -33,6 +34,7 @@ license.workspace = true
 name = "aic-sdk"
 readme = "README.md"
 repository.workspace = true
+rust-version.workspace = true
 version.workspace = true
 
 [dependencies]

--- a/aic-model-downloader/Cargo.toml
+++ b/aic-model-downloader/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 name = "aic-model-downloader"
 readme = "README.md"
 repository.workspace = true
+rust-version.workspace = true
 version.workspace = true
 
 [dependencies]

--- a/aic-sdk-sys/Cargo.toml
+++ b/aic-sdk-sys/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 name = "aic-sdk-sys"
 readme = "README.md"
 repository.workspace = true
+rust-version.workspace = true
 version.workspace = true
 
 [package.metadata.docs.rs]

--- a/examples/build-time-download/Cargo.toml
+++ b/examples/build-time-download/Cargo.toml
@@ -3,6 +3,7 @@ edition.workspace = true
 license.workspace = true
 name = "build-time-download"
 publish = false
+rust-version.workspace = true
 version.workspace = true
 
 [dependencies]


### PR DESCRIPTION
This explicitly marks the minimum supported toolchain. Please review and let me know if you think this could break something.